### PR TITLE
Clean pipeline init modules

### DIFF
--- a/services/pipeline/src/pipeline/__init__.py
+++ b/services/pipeline/src/pipeline/__init__.py
@@ -1,13 +1,1 @@
-codex/create-ingest_orderbook.py-in-pipeline/data
-from __future__ import annotations
-
-from typing import List
-
-__all__: List[str] = []
-
-codex/create-ingest_news.py-for-news-ingestion
-__all__: list[str] 
-from __future__ import annotations
-
-__all__: list[str] = []main
- main
+"""Core pipeline package."""

--- a/services/pipeline/src/pipeline/data/__init__.py
+++ b/services/pipeline/src/pipeline/data/__init__.py
@@ -1,10 +1,31 @@
-codex/create-ingest_news.py-for-news-ingestion
-from .ingest_news import IngestNewsInput, IngestNewsOutput, run
+"""Data ingestion modules."""
+
+from .ingest_news import IngestNewsInput, IngestNewsOutput
+from .ingest_news import run as ingest_news
+from .ingest_onchain import IngestOnchainInput, IngestOnchainOutput
+from .ingest_onchain import run as ingest_onchain
+from .ingest_orderbook import IngestOrderbookInput, IngestOrderbookOutput
+from .ingest_orderbook import run as ingest_orderbook
+from .ingest_prices import IngestPricesInput, IngestPricesOutput
+from .ingest_prices import run as ingest_prices
+from .ingest_prices_lowtf import (IngestPricesLowTFInput,
+                                  IngestPricesLowTFOutput)
+from .ingest_prices_lowtf import run as ingest_prices_lowtf
 
 __all__ = [
     "IngestNewsInput",
     "IngestNewsOutput",
-    "run",
+    "ingest_news",
+    "IngestOnchainInput",
+    "IngestOnchainOutput",
+    "ingest_onchain",
+    "IngestOrderbookInput",
+    "IngestOrderbookOutput",
+    "ingest_orderbook",
+    "IngestPricesInput",
+    "IngestPricesOutput",
+    "ingest_prices",
+    "IngestPricesLowTFInput",
+    "IngestPricesLowTFOutput",
+    "ingest_prices_lowtf",
 ]
-"""Data ingestion modules."""
- main


### PR DESCRIPTION
## Summary
- simplify pipeline package init
- centralize data ingestion imports and exports

## Testing
- `pytest`
- `pre-commit run --files services/pipeline/src/pipeline/__init__.py services/pipeline/src/pipeline/data/__init__.py` *(fails: isort modifies files)*

------
https://chatgpt.com/codex/tasks/task_e_68bff2bd8220832d8fe8fb5aaf996e41