### PR TITLE
Clean up ingest news input model

### DIFF
--- a/services/pipeline/src/pipeline/data/ingest_news.py
+++ b/services/pipeline/src/pipeline/data/ingest_news.py
@@ -10,7 +10,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import requests  # type: ignore[import-untyped]
 from loguru import logger
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from textblob import TextBlob
 
 from ..infra.s3 import upload_bytes
@@ -31,11 +31,8 @@ class IngestNewsInput(BaseModel):
     slot: str
     time_window_hours: int = 12
     query: str = "crypto OR bitcoin"
-codex/create-task-list-for-project-completion-qym2g0
-
     news_signals: List[dict] = Field(default_factory=list)
     news_facts: Optional[List[dict]] = None
- main
 
 
 class IngestNewsOutput(BaseModel):


### PR DESCRIPTION
## Summary
- fix pydantic import and IngestNewsInput fields

## Testing
- `ruff check services/pipeline/src/pipeline/data/ingest_news.py`
- `PYTHONPATH=services/pipeline/src python -m pipeline.data.ingest_news`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfff4a910c832dac1237c09ffd4f92