### PR TITLE
Add health endpoint and package metadata

### DIFF
--- a/services/pipeline/pyproject.toml
+++ b/services/pipeline/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pipeline"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "ccxt==4.3.59",
+    "pandas==2.2.2",
+    "pyarrow==17.0.0",
+    "boto3==1.34.159",
+    "pydantic==2.8.2",
+    "loguru==0.7.2",
+    "python-dateutil==2.9.0.post0",
+    "requests==2.32.3",
+    "python-telegram-bot==21.4",
+    "textblob==0.18.0.post0",
+    "nltk==3.9.1",
+    "psycopg2-binary==2.9.9",
+    "statsmodels==0.14.2",
+    "matplotlib==3.9.2",
+    "openai==1.46.0",
+    "prometheus-client==0.20.0",
+    "sentry-sdk==2.13.0",
+    "redis==5.0.7",
+    "optuna==3.6.1",
+    "mlflow==2.16.0",
+    "feedparser==6.0.11",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/services/pipeline/src/pipeline/infra/health.py
+++ b/services/pipeline/src/pipeline/infra/health.py
@@ -1,0 +1,39 @@
+"""Minimal HTTP health endpoint."""
+
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Tuple
+
+from .healthcheck import run
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802 - required name
+        status, body = self._health_response()
+        self.send_response(status)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A003 - inherited
+        """Silence the default HTTP server logging."""
+        return
+
+    def _health_response(self) -> Tuple[int, bytes]:
+        if self.path != "/health":
+            return 404, b"Not Found"
+        ok = run()
+        return (200, b"OK") if ok else (500, b"FAIL")
+
+
+def serve(host: str = "0.0.0.0", port: int = 8000) -> None:  # nosec B104
+    """Start health check HTTP server."""
+    HTTPServer((host, port), _Handler).serve_forever()
+
+
+def main() -> None:
+    serve()
+
+
+if __name__ == "__main__":
+    main()

--- a/services/pipeline/src/pipeline/mcp/__init__.py
+++ b/services/pipeline/src/pipeline/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP subsystem."""

--- a/services/pipeline/src/pipeline/ops/__init__.py
+++ b/services/pipeline/src/pipeline/ops/__init__.py
@@ -1,0 +1,1 @@
+"""Operations utilities."""


### PR DESCRIPTION
## Summary
- add minimal HTTP /health server
- declare pipeline package dependencies via pyproject
- initialize missing subpackages and fix predict_release import

## Testing
- `pip install -e services/pipeline`
- `pre-commit run --files services/pipeline/src/pipeline/orchestration/predict_release.py services/pipeline/src/pipeline/infra/health.py services/pipeline/src/pipeline/mcp/__init__.py services/pipeline/src/pipeline/ops/__init__.py services/pipeline/pyproject.toml`
- `ruff check services/pipeline/src/pipeline/orchestration/predict_release.py services/pipeline/src/pipeline/infra/health.py services/pipeline/src/pipeline/mcp/__init__.py services/pipeline/src/pipeline/ops/__init__.py`
- `black --check services/pipeline/src/pipeline/orchestration/predict_release.py services/pipeline/src/pipeline/infra/health.py services/pipeline/src/pipeline/mcp/__init__.py services/pipeline/src/pipeline/ops/__init__.py`
- `mypy --follow-imports=skip --ignore-missing-imports services/pipeline/src/pipeline/orchestration/predict_release.py services/pipeline/src/pipeline/infra/health.py services/pipeline/src/pipeline/mcp/__init__.py services/pipeline/src/pipeline/ops/__init__.py`
- `bandit services/pipeline/src/pipeline/orchestration/predict_release.py services/pipeline/src/pipeline/infra/health.py services/pipeline/src/pipeline/mcp/__init__.py services/pipeline/src/pipeline/ops/__init__.py`
- `DRY_RUN=1 ENABLE_ORDERBOOK=0 ENABLE_ONCHAIN=0 USE_COORDINATOR=0 S3_ENDPOINT_URL=http://localhost:9000 python -m pipeline.orchestration.predict_release` (fails: Redis lock error, fallback message printed)


------
https://chatgpt.com/codex/tasks/task_e_68c0c6b1c4d4832db0175740bd657960