### PR TITLE
Handle missing on-chain API keys gracefully

### DIFF
--- a/services/pipeline/src/pipeline/orchestration/predict_release.py
+++ b/services/pipeline/src/pipeline/orchestration/predict_release.py
@@ -114,7 +114,8 @@ def predict_release(
                     IngestOnchainInput(run_id=run_id, slot=slot, asset="BTC")
                 )
                 onchain_signals = [s.model_dump() for s in oc_out.onchain_signals]
-        except Exception:
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(f"On-chain ingest failed: {exc}")
             onchain_signals = []
 
     # Features


### PR DESCRIPTION
## Summary
- log failures during on-chain signal ingestion and continue without signals
- skip on-chain metrics when `GLASSNODE_API_KEY` is missing or persistence fails

## Testing
- `pre-commit run --files services/pipeline/src/pipeline/data/ingest_onchain.py services/pipeline/src/pipeline/orchestration/predict_release.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0ddfa37e4832dad957d0f5f802061