### PR TITLE
Avoid weighting LLM predictions without CV metrics

### DIFF
--- a/services/pipeline/src/pipeline/orchestration/agent_flow.py
+++ b/services/pipeline/src/pipeline/orchestration/agent_flow.py
@@ -1941,7 +1941,7 @@ def run_release_flow(
 
             l4, h4 = _interval(y_hat, atr, 240)
             l12, h12 = _interval(y_hat, atr, 720)
-            cv_stub = {"smape": 20.0, "da": 0.5, "source": "llm"}
+            cv_stub = {"source": "llm"}
             llm_pred4 = {
                 "model": "llm_news",
                 "y_hat": y_hat,


### PR DESCRIPTION
## Summary
- Drop fake sMAPE/DA metrics from LLM agent predictions
- Assign zero weight to models missing sMAPE so unvalidated LLM forecasts don't influence ensembles

## Testing
- `pre-commit run --files services/pipeline/src/pipeline/ensemble/ensemble_rank.py services/pipeline/src/pipeline/orchestration/agent_flow.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0de07c26c832db9811d9bee25e003