### PR TITLE
docs: refresh README with new modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ reasoning/	Объяснения и арбитраж аргументов (LLM/fa
 trading/	Формирование торговой карты, проверка, бумажная и живая торговля, риск‑менеджмент.
 reporting/	Генерация графиков и PDF‑/MD‑отчётов; публикация в Telegram.
 orchestration/	Сценарии запуска (predict_release, agent_flow), планировщик.
+agents/        Базовые классы и координатор агентов.
+mcp/           Мини‑сервер и клиент MCP для безопасного вызова инструментов.
+utils/         Общие утилиты (калибровка, текст).
 infra/	База данных (Postgres + pgvector), кеш Redis, s3/minio, логи и метрики.
 migrations/	SQL‑миграции для PostgreSQL (таблицы для цен, сигналов, прогнозов, торговых позиций и др.).
 ops/	Инфраструктура и наблюдаемость (Prometheus, Grafana, алерты, Windmill flows).
-Дополнительная документация находится в docs/ — читайте ARCHITECTURE.md для схемы потоков, AGENTS.md для списка агентов, DATA_SOURCES.md для источников данных, ENV.md для краткого описания переменных окружения и OPERATIONS.md для запуска и наблюдаемости. Документ DB_SCHEMA.md описывает основные таблицы. В этом README собраны краткие инструкции по запуску и отладке.
+Дополнительная документация находится в docs/ — читайте ARCHITECTURE.md для схемы потоков, DATA_SOURCES.md для источников данных, DB_SCHEMA.md для описания таблиц, ENV.md для переменных окружения, OPERATIONS.md для запуска и наблюдаемости и TRADING.md для режимов торговли. В этом README собраны краткие инструкции по запуску и отладке.
 Поток релиза
 В стандартном сценарии pipeline запускается дважды в день (12:00 и 00:00 по Asia/Jerusalem), но можно запускать вручную. Основные шаги:
     1. Ingest: загрузка цен, новостей и (по флагам) стакана, ончейна, фьючерсов, соц‑сетей, альт‑данных. Данные сохраняются в S3 и публикуют метрики.
@@ -33,7 +36,7 @@ ops/	Инфраструктура и наблюдаемость (Prometheus, Gr
     1. Склонируйте репозиторий и подготовьте окружение:
 git clone https://github.com/Softis1237/CryptoIA.git
 cd CryptoIA
-cp .env.example .env  # заполните переменные, см. docs/ENV.md и ENV_FULL.md
+cp .env.example .env  # заполните переменные, см. docs/ENV.md
 Укажите ключи API (Glassnode, CryptoPanic, NewsAPI, CryptoQuant и др.), секреты S3/MinIO и параметры базы данных. По умолчанию сервис работает в таймзоне Asia/Jerusalem.
     1. Запустите инфраструктуру (Postgres + Redis + MinIO + Prometheus / Grafana) и основные сервисы:
 docker compose up -d --build
@@ -41,17 +44,18 @@ docker compose up -d --build
     1. Запустите релиз вручную (например, для отладки):
 docker compose run --rm pipeline python -m pipeline.orchestration.predict_release --slot=manual
 Или воспользуйтесь DAG: USE_COORDINATOR=1 и python -m pipeline.orchestration.agent_flow --slot=manual.
-    1. Проверка здоровья: эндпоинт /health не реализован, но можно проверить логи контейнеров (docker compose logs -f pipeline scheduler) и метрики (http://localhost:9091/metrics).
+    1. Проверка здоровья: сервис поднимает HTTP эндпоинт http://localhost:8000/health. Он возвращает `OK`, если Postgres и S3 доступны; в противном случае ответит `FAIL`. Дополнительно смотрите логи контейнеров (`docker compose logs -f pipeline scheduler`) и метрики (http://localhost:9091/metrics).
     2. Режимы торговли:
     3. Бумажная торговля: включайте DRY_RUN=1 (по умолчанию) и используйте python -m pipeline.trading.paper_trading executor_once для открытия позиций. Все сделки записываются в paper_positions и связанные таблицы.
     4. Живая торговля: установите EXCHANGE_API_KEY, EXCHANGE_SECRET, EXCHANGE_TYPE и DRY_RUN=0. Скрипт python -m pipeline.trading.executor_live откроет сделку из последнего предложения. Скрипт python -m pipeline.trading.risk_loop_live следит за trailing‑stop и перемещает стоп при улучшении цены (см. docs/TRADING.md).
     5. Обучение ML моделей: для использования LGBM/XGBoost/CatBoost моделей активируйте стэкинг (ENABLE_STACKING=1) и выполняйте python -m pipeline.ops.retrain. Существует Flow ops/windmill/flows/train_ml_register.py для автоматизации.
     6. Наблюдаемость: укажите PROM_PUSHGATEWAY_URL для отправки метрик. Для мониторинга ошибок задайте SENTRY_DSN.
 Переменные окружения
-Список основных переменных с короткими пояснениями приведён в docs/ENV.md. Для полного списка, категорий и значений по умолчанию смотрите документ ENV_FULL.md в этой директории. Настройка правильных API‑ключей критически важна: без них компоненты (например, ончейн или фьючерсы) не будут активированы.
+Список основных переменных с короткими пояснениями приведён в docs/ENV.md. Настройка правильных API‑ключей критически важна: без них компоненты (например, ончейн или фьючерсы) не будут активированы.
 Расширенные возможности
     • Многоагентный режим (Agent Coordinator): активируется USE_COORDINATOR=1 и использует DAG из orchestration/agent_flow.py. Агент flow строит зависимости между ingest, models, ensemble, reasoning, сценарием и трейдом, записывает метрики и артефакты.
-    • Flowise endpoints: можно подключить внешние LLM-пайплайны для объяснения (FLOWISE_EXPLAIN_URL), дебатов (FLOWISE_DEBATE_URL), сценариев (FLOWISE_SCENARIO_URL) и валидации. При отсутствии — используются fallback-эвристики.
+    • Flowise endpoints: можно подключить внешние LLM‑пайплайны для объяснения (FLOWISE_EXPLAIN_URL), дебатов (FLOWISE_DEBATE_URL), сценариев (FLOWISE_SCENARIO_URL) и валидации. При отсутствии используются встроенные эвристики и валидаторы.
+    • Мини‑MCP сервер: модуль mcp/ открывает безопасные HTTP-инструменты (get_features_tail, levels_quantiles, news_top) для LLM и других клиентов.
     • Alt‑данные: модуль ingest_altdata собирает тренды Google, открытый интерес CME, опционы, данные ликвидности и RSS события. Включается флагом ENABLE_ALT_DATA=1 и требует ключей Quandl/Coinglass.
     • Регулярные retrain/feedback: скрипт pipeline.ops.feedback_metrics собирает факт результов предсказаний, рассчитывает ошибки, тэги коренных причин и пушит агрегаты в Prometheus. Его можно запускать раз в день (см. ops/windmill/flows/feedback_metrics_daily.py).
     • Многоуровневая валидация: существуют валидаторы (trade_validator, regime_validator, llm_validator), которые могут отклонять сделки или прогнозы. Они вызываются координатором, если активирован ENABLE_LLM_VALIDATOR и настроен FLOWISE_VALIDATE_URL.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -12,6 +12,11 @@ docker compose up -d --build
 docker compose run --rm pipeline python -m pipeline.orchestration.agent_flow --slot=manual
 ```
 
+Проверка здоровья:
+
+- HTTP эндпоинт `http://localhost:8000/health` возвращает `OK`, если доступны Postgres и S3.
+- При `FAIL` проверьте логи контейнеров и настройки подключения.
+
 Метрики Prometheus:
 - Укажите `PROM_PUSHGATEWAY_URL`.
 - Пушатся: `pipeline_step_seconds`, `pipeline_value` (бизнес/валид./риск метрики).


### PR DESCRIPTION
## Summary
- document new `agents`, `mcp`, and `utils` modules
- add Trading guide and MCP server details to README
- remove outdated links to missing docs
- document HTTP health check and validator usage

## Testing
- `pre-commit run --files README.md docs/OPERATIONS.md`


------
https://chatgpt.com/codex/tasks/task_e_68c0e266c58c832d8f10d86ce78f1bff