### PR TITLE
refactor: dedupe LLM helpers and improve error handling

### DIFF
--- a/services/pipeline/src/pipeline/data/ingest_news.py
+++ b/services/pipeline/src/pipeline/data/ingest_news.py
@@ -78,8 +78,15 @@ def _get_news_sentiments_llm(
             "FLOWISE_SENTIMENT_URL", {"system": system_prompt, "user": user_prompt}
         )
 
-        if not results or not isinstance(results, list):
+        if (
+            not results
+            or isinstance(results, dict)
+            and results.get("status") == "error"
+        ):
             logger.warning("Flowise sentiment call returned no valid data.")
+            return {}
+        if not isinstance(results, list):
+            logger.warning("Flowise sentiment call returned unexpected format.")
             return {}
 
         # The result should be a list of dicts. We map it back to the original news items by URL.


### PR DESCRIPTION
## Summary
- remove duplicated code in LLM helpers and centralize Flowise response parsing
- return structured error info with request logging for OpenAI and Flowise calls
- update call sites to respect new error status

## Testing
- `pre-commit run --files services/pipeline/src/pipeline/reasoning/llm.py services/pipeline/src/pipeline/reasoning/debate_arbiter.py services/pipeline/src/pipeline/reasoning/news_facts.py services/pipeline/src/pipeline/reasoning/explain.py services/pipeline/src/pipeline/scenarios/scenario_helper.py services/pipeline/src/pipeline/data/ingest_news.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0e529c308832d881fca1a0ac93952