### PR TITLE
schedule subscription reminders and sweep

### DIFF
--- a/ops/windmill/flows/subscriptions_remind_24.py
+++ b/ops/windmill/flows/subscriptions_remind_24.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+
+
+def main() -> None:
+    if "/app/src" not in sys.path:
+        sys.path.append("/app/src")
+    from pipeline.trading.subscriptions import send_renew_reminders
+
+    c = send_renew_reminders(hours_before=24)
+    print(f"reminders={c}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/windmill/flows/subscriptions_remind_72.py
+++ b/ops/windmill/flows/subscriptions_remind_72.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+
+
+def main() -> None:
+    if "/app/src" not in sys.path:
+        sys.path.append("/app/src")
+    from pipeline.trading.subscriptions import send_renew_reminders
+
+    c = send_renew_reminders(hours_before=72)
+    print(f"reminders={c}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/windmill/schedules/pipeline.yaml
+++ b/ops/windmill/schedules/pipeline.yaml
@@ -12,3 +12,12 @@ schedules:
   - name: cleanup_old_runs
     flow: flows/cleanup_old_runs.py
     cron: "0 2 * * *"
+  - name: subscriptions_sweep_hourly
+    flow: flows/subscriptions_sweep.py
+    cron: "0 * * * *"
+  - name: subscriptions_remind_72h
+    flow: flows/subscriptions_remind_72.py
+    cron: "0 9,21 * * *"
+  - name: subscriptions_remind_24h
+    flow: flows/subscriptions_remind_24.py
+    cron: "30 9,21 * * *"

--- a/services/pipeline/src/pipeline/trading/publish_telegram.py
+++ b/services/pipeline/src/pipeline/trading/publish_telegram.py
@@ -22,15 +22,28 @@ def _chunk_text(text: str, limit: int = 4096):
 
 def publish_message(text: str) -> None:
     if not settings.telegram_bot_token or not settings.telegram_chat_id:
-        logger.warning("TELEGRAM_BOT_TOKEN/TELEGRAM_CHAT_ID не заданы — печатаю локально:\n" + text)
+        logger.warning(
+            "TELEGRAM_BOT_TOKEN/TELEGRAM_CHAT_ID не заданы — печатаю локально:\n" + text
+        )
         print(text)
         return
+    try:
+        from .subscriptions import sweep_and_revoke_channel_access
+
+        sweep_and_revoke_channel_access()
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"Failed to sweep expired subscriptions: {e}")
     try:
         from telegram import Bot
 
         bot = Bot(token=settings.telegram_bot_token)
         for chunk in _chunk_text(text):
-            bot.send_message(chat_id=settings.telegram_chat_id, text=chunk, parse_mode="HTML", disable_web_page_preview=True)
+            bot.send_message(
+                chat_id=settings.telegram_chat_id,
+                text=chunk,
+                parse_mode="HTML",
+                disable_web_page_preview=True,
+            )
         logger.info("Отправлено в Telegram")
     except Exception as e:  # noqa: BLE001
         logger.exception(f"Ошибка публикации в Telegram: {e}")
@@ -38,7 +51,9 @@ def publish_message(text: str) -> None:
 
 def publish_message_to(chat_id: str, text: str) -> None:
     if not settings.telegram_bot_token or not chat_id:
-        logger.warning("TELEGRAM_BOT_TOKEN/CHAT_ID не заданы — печатаю локально:\n" + text)
+        logger.warning(
+            "TELEGRAM_BOT_TOKEN/CHAT_ID не заданы — печатаю локально:\n" + text
+        )
         print(text)
         return
     try:
@@ -46,7 +61,12 @@ def publish_message_to(chat_id: str, text: str) -> None:
 
         bot = Bot(token=settings.telegram_bot_token)
         for chunk in _chunk_text(text):
-            bot.send_message(chat_id=chat_id, text=chunk, parse_mode="HTML", disable_web_page_preview=True)
+            bot.send_message(
+                chat_id=chat_id,
+                text=chunk,
+                parse_mode="HTML",
+                disable_web_page_preview=True,
+            )
         logger.info(f"Отправлено в Telegram chat {chat_id}")
     except Exception as e:  # noqa: BLE001
         logger.exception(f"Ошибка публикации в Telegram (target): {e}")
@@ -56,14 +76,27 @@ def publish_photo_from_s3(s3_uri: str, caption: str | None = None) -> None:
     if not s3_uri:
         return
     if not settings.telegram_bot_token or not settings.telegram_chat_id:
-        logger.warning("TELEGRAM_* не заданы — пропускаю отправку фото, путь: " + s3_uri)
+        logger.warning(
+            "TELEGRAM_* не заданы — пропускаю отправку фото, путь: " + s3_uri
+        )
         return
+    try:
+        from .subscriptions import sweep_and_revoke_channel_access
+
+        sweep_and_revoke_channel_access()
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"Failed to sweep expired subscriptions: {e}")
     try:
         from telegram import Bot
 
         content = download_bytes(s3_uri)
         bot = Bot(token=settings.telegram_bot_token)
-        bot.send_photo(chat_id=settings.telegram_chat_id, photo=content, caption=caption or "", parse_mode="HTML")
+        bot.send_photo(
+            chat_id=settings.telegram_chat_id,
+            photo=content,
+            caption=caption or "",
+            parse_mode="HTML",
+        )
         logger.info("Фотография отправлена в Telegram")
     except Exception as e:  # noqa: BLE001
         logger.exception(f"Ошибка отправки фото в Telegram: {e}")


### PR DESCRIPTION
## Summary
- schedule hourly subscription sweep and twice-daily reminders (72h and 24h)
- clean expired users from Telegram channel before publishing forecasts

## Testing
- `pre-commit run --files ops/windmill/flows/subscriptions_remind_24.py ops/windmill/flows/subscriptions_remind_72.py ops/windmill/schedules/pipeline.yaml services/pipeline/src/pipeline/trading/publish_telegram.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2252ef284832d90fee18c0daab77f