### PR TITLE
Добавлен CLI для анализа рынка

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,6 @@ precommit:
 pipeline-shell:
 	docker compose run --rm pipeline bash
 
+
+analyze:
+	python -m pipeline.cli.analysis $(ARGS)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ docker compose up -d --build
 docker compose run --rm pipeline python -m pipeline.orchestration.predict_release --slot=manual
 Или воспользуйтесь DAG: USE_COORDINATOR=1 и python -m pipeline.orchestration.agent_flow --slot=manual.
     1. Проверка здоровья: сервис поднимает HTTP эндпоинт http://localhost:8000/health. Он возвращает `OK`, если Postgres и S3 доступны; в противном случае ответит `FAIL`. Дополнительно смотрите логи контейнеров (`docker compose logs -f pipeline scheduler`) и метрики (http://localhost:9091/metrics).
-    2. Режимы торговли:
+
+    2. Анализ: `make analyze ARGS="price <path>"` — выводит последние метрики (price, orderflow, supply-demand, patterns).
+    3. Режимы торговли:
     3. Бумажная торговля: включайте DRY_RUN=1 (по умолчанию) и используйте python -m pipeline.trading.paper_trading executor_once для открытия позиций. Все сделки записываются в paper_positions и связанные таблицы.
     4. Живая торговля: установите EXCHANGE_API_KEY, EXCHANGE_SECRET, EXCHANGE_TYPE и DRY_RUN=0. Скрипт python -m pipeline.trading.executor_live откроет сделку из последнего предложения. Скрипт python -m pipeline.trading.risk_loop_live следит за trailing‑stop и перемещает стоп при улучшении цены (см. docs/TRADING.md).
     5. Обучение ML моделей: для использования LGBM/XGBoost/CatBoost моделей активируйте стэкинг (ENABLE_STACKING=1) и выполняйте python -m pipeline.ops.retrain. Существует Flow ops/windmill/flows/train_ml_register.py для автоматизации.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -20,6 +20,15 @@ docker compose run --rm pipeline python -m pipeline.orchestration.agent_flow --s
 - HTTP эндпоинт `http://localhost:8000/health` возвращает `OK`, если доступны Postgres и S3.
 - При `FAIL` проверьте логи контейнеров и настройки подключения.
 
+Анализ последних метрик:
+
+```
+make analyze ARGS="price data/prices.parquet"
+```
+
+Выведет JSON с последними индикаторами цены. Аналогично доступны команды `orderflow`, `supply-demand` и `patterns` для соответствующих данных.
+
+
 Метрики Prometheus:
 - Укажите `PROM_PUSHGATEWAY_URL`.
 - Пушатся: `pipeline_step_seconds`, `pipeline_value` (бизнес/валид./риск метрики).

--- a/services/pipeline/src/pipeline/cli/__init__.py
+++ b/services/pipeline/src/pipeline/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI utilities for pipeline service."""

--- a/services/pipeline/src/pipeline/cli/analysis.py
+++ b/services/pipeline/src/pipeline/cli/analysis.py
@@ -1,0 +1,137 @@
+# flake8: noqa
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Dict
+
+import pandas as pd
+
+from ..features.features_calc import _atr, _ema, _rsi
+from ..features.features_patterns import detect_patterns
+
+
+def _read_bytes(path: str) -> bytes:
+    if path.startswith("s3://"):
+        from ..infra.s3 import download_bytes
+
+        return download_bytes(path)
+    with open(path, "rb") as f:
+        return f.read()
+
+
+def cmd_price(args: argparse.Namespace) -> None:
+    df = pd.read_parquet(args.path).sort_values("ts").reset_index(drop=True)
+    ema20 = _ema(df["close"], 20).iloc[-1]
+    ema50 = _ema(df["close"], 50).iloc[-1]
+    rsi14 = _rsi(df["close"], 14).iloc[-1]
+    atr14 = _atr(df, 14).iloc[-1]
+    out = {
+        "close": float(df["close"].iloc[-1]),
+        "ema20": float(ema20),
+        "ema50": float(ema50),
+        "rsi14": float(rsi14),
+        "atr14": float(atr14),
+    }
+    print(json.dumps(out, ensure_ascii=False))
+
+
+def cmd_orderflow(args: argparse.Namespace) -> None:
+    df = pd.read_parquet(args.path).sort_values("ts").reset_index(drop=True)
+    if df.empty:
+        metrics = {
+            "ofi_1m": 0.0,
+            "delta_vol_1m": 0.0,
+            "trades_per_sec": 0.0,
+            "avg_trade_size": 0.0,
+        }
+    else:
+        dt = pd.to_datetime(df["ts"], unit="s", utc=True)
+        df = df.set_index(dt)
+        buy = df[df["side"] == "buy"]["amount"].resample("1min").sum().fillna(0.0)
+        sell = df[df["side"] == "sell"]["amount"].resample("1min").sum().fillna(0.0)
+        total = df["amount"].resample("1min").sum().fillna(0.0)
+        count = df["amount"].resample("1min").count().fillna(0)
+        ofi = (buy - sell) / total.replace(0.0, pd.NA)
+        ofi = ofi.fillna(0.0)
+        delta_vol = (buy - sell).fillna(0.0)
+        trades_per_sec = (count / 60.0).astype(float)
+        avg_trade_size = (total / count.replace(0, pd.NA)).fillna(0.0)
+        last = (
+            pd.DataFrame(
+                {
+                    "ofi": ofi,
+                    "delta_vol": delta_vol,
+                    "trades_per_sec": trades_per_sec,
+                    "avg_trade_size": avg_trade_size,
+                }
+            )
+            .reset_index()
+            .tail(1)
+            .iloc[0]
+        )
+        metrics = {
+            "ofi_1m": float(last.get("ofi", 0.0) or 0.0),
+            "delta_vol_1m": float(last.get("delta_vol", 0.0) or 0.0),
+            "trades_per_sec": float(last.get("trades_per_sec", 0.0) or 0.0),
+            "avg_trade_size": float(last.get("avg_trade_size", 0.0) or 0.0),
+        }
+    print(json.dumps(metrics, ensure_ascii=False))
+
+
+def cmd_supply_demand(args: argparse.Namespace) -> None:
+    meta: Dict[str, Any] = json.loads(args.json)
+    bid_vol = float(meta.get("bid_vol", 0.0) or 0.0)
+    ask_vol = float(meta.get("ask_vol", 0.0) or 0.0)
+    depth = float(meta.get("depth", 0.0) or 0.0)
+    imbalance = float(meta.get("imbalance", 0.0) or 0.0)
+    bid_n = float(meta.get("bid_n", 0.0) or 0.0)
+    ask_n = float(meta.get("ask_n", 0.0) or 0.0)
+    depth_ratio = bid_vol / (ask_vol + 1e-9) if (bid_vol or ask_vol) else 1.0
+    total_liq = bid_vol + ask_vol
+    orders_count = bid_n + ask_n
+    out = {
+        "ob_imbalance": imbalance,
+        "ob_depth_ratio": depth_ratio,
+        "ob_total_liq": total_liq,
+        "ob_depth": depth,
+        "ob_bid_levels": bid_n,
+        "ob_ask_levels": ask_n,
+        "ob_orders_count": orders_count,
+    }
+    print(json.dumps(out, ensure_ascii=False))
+
+
+def cmd_patterns(args: argparse.Namespace) -> None:
+    df = pd.read_parquet(args.path).sort_values("ts").reset_index(drop=True)
+    pat_map = detect_patterns(df)
+    out = {k: float(v.iloc[-1]) for k, v in pat_map.items()}
+    print(json.dumps(out, ensure_ascii=False))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Market analysis utilities")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_price = sub.add_parser("price", help="Latest price metrics from parquet")
+    p_price.add_argument("path", help="Path or S3 URI to prices parquet")
+    p_price.set_defaults(func=cmd_price)
+
+    p_of = sub.add_parser("orderflow", help="Order flow metrics from trades parquet")
+    p_of.add_argument("path", help="Path or S3 URI to trades parquet")
+    p_of.set_defaults(func=cmd_orderflow)
+
+    p_sd = sub.add_parser("supply-demand", help="Metrics from orderbook meta JSON")
+    p_sd.add_argument("json", help="Orderbook meta as JSON string")
+    p_sd.set_defaults(func=cmd_supply_demand)
+
+    p_pat = sub.add_parser("patterns", help="Detect candlestick patterns from parquet")
+    p_pat.add_argument("path", help="Path or S3 URI to prices parquet")
+    p_pat.set_defaults(func=cmd_patterns)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/services/pipeline/tests/test_cli_analysis.py
+++ b/services/pipeline/tests/test_cli_analysis.py
@@ -1,0 +1,79 @@
+# flake8: noqa
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+def run_cli(args):
+    cmd = [sys.executable, "-m", "pipeline.cli.analysis", *args]
+    env = dict(os.environ)
+    root = Path(__file__).resolve().parents[1] / "src"
+    env["PYTHONPATH"] = str(root)
+    res = subprocess.run(cmd, capture_output=True, text=True, check=True, env=env)
+    return json.loads(res.stdout.strip())
+
+
+def test_price(tmp_path: Path):
+    df = pd.DataFrame(
+        {
+            "ts": [0, 60, 120],
+            "open": [10, 11, 12],
+            "high": [11, 12, 13],
+            "low": [9, 10, 11],
+            "close": [10, 11, 12],
+            "volume": [100, 110, 120],
+        }
+    )
+    path = tmp_path / "prices.parquet"
+    df.to_parquet(path)
+    out = run_cli(["price", str(path)])
+    assert "close" in out and "ema20" in out
+
+
+def test_orderflow(tmp_path: Path):
+    df = pd.DataFrame(
+        {
+            "ts": [0, 30, 60],
+            "price": [10, 10.5, 11],
+            "amount": [1, 2, 1.5],
+            "side": ["buy", "sell", "buy"],
+        }
+    )
+    path = tmp_path / "trades.parquet"
+    df.to_parquet(path)
+    out = run_cli(["orderflow", str(path)])
+    assert "ofi_1m" in out
+
+
+def test_supply_demand():
+    meta = {
+        "bid_vol": 100,
+        "ask_vol": 80,
+        "depth": 20,
+        "imbalance": 0.1,
+        "bid_n": 10,
+        "ask_n": 8,
+    }
+    out = run_cli(["supply-demand", json.dumps(meta)])
+    assert out["ob_total_liq"] == 180
+
+
+def test_patterns(tmp_path: Path):
+    df = pd.DataFrame(
+        {
+            "ts": [0, 60, 120],
+            "open": [10, 11, 12],
+            "high": [11, 12, 13],
+            "low": [9, 10, 11],
+            "close": [10, 12, 11],
+            "volume": [100, 100, 100],
+        }
+    )
+    path = tmp_path / "prices.parquet"
+    df.to_parquet(path)
+    out = run_cli(["patterns", str(path)])
+    assert "pat_hammer" in out


### PR DESCRIPTION
## Summary
- добавлен модуль `pipeline.cli.analysis` с командами price, orderflow, supply-demand и patterns
- добавлены тесты и цель Makefile `analyze`
- обновлена документация (README, OPERATIONS)

## Testing
- `pre-commit run --files services/pipeline/src/pipeline/cli/analysis.py services/pipeline/tests/test_cli_analysis.py`
- `pytest services/pipeline/tests/test_cli_analysis.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6a3803f408332b268f506e7706958