### PR TITLE
feat: add multilingual affiliate footer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,7 @@ PROMO_BANNER_S3_NIGHT=
 EXTERNAL_AFF_LINK_URL=https://bingx.com/invite/HR1XAY/
 EXTERNAL_AFF_LINK_TEXT=💠 Бонусы на бирже
 EXTERNAL_AFF_FOOTER_EN=Recommended exchange:
+EXTERNAL_AFF_FOOTER_RU=Рекомендуемая биржа:
 ENABLE_NEWS=1
 # OpenAI (для будущих модулей)
 OPENAI_API_KEY= sk-xxxxx

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -147,6 +147,9 @@ PRICE_STARS_MONTH, PRICE_STARS_YEAR — стоимость подписки в�
 
 CRYPTO_PAYMENT_URL — ссылка на оплату в криптовалюте.
 
+EXTERNAL_AFF_LINK_URL — ссылка на внешнюю партнёрскую биржу, добавляется в конец сообщений и подписей.
+EXTERNAL_AFF_FOOTER_EN, EXTERNAL_AFF_FOOTER_RU — текст префикса для ссылки (по умолчанию «Recommended exchange:» и «Рекомендуемая биржа:»).
+
 
 TELEGRAM_PRIVATE_CHANNEL_ID, TELEGRAM_ADMIN_CHAT_ID, TELEGRAM_OWNER_ID, TELEGRAM_ADMIN_IDS — каналы для подписки, админских сообщений, владельца и список ID админов.
 

--- a/services/pipeline/src/pipeline/trading/publish_telegram.py
+++ b/services/pipeline/src/pipeline/trading/publish_telegram.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import os
+
 from loguru import logger
 
 from ..infra.config import settings
-from ..infra.s3 import download_bytes
 from ..infra.db import list_active_subscriber_ids
+from ..infra.s3 import download_bytes
 
 
 def _chunk_text(text: str, limit: int = 4096):
@@ -29,18 +30,35 @@ def _dm_user_ids() -> list[str]:
     return [x.strip() for x in raw.replace("\n", ",").split(",") if x.strip()]
 
 
-def _append_aff_footer(text: str) -> str:
+def _append_aff_footer(text: str, lang: str = "en") -> str:
     url = os.getenv("EXTERNAL_AFF_LINK_URL", "").strip()
     if not url:
         return text
-    prefix = os.getenv("EXTERNAL_AFF_FOOTER_EN", "Recommended exchange:").strip()
+    if lang == "ru":
+        prefix = os.getenv(
+            "EXTERNAL_AFF_FOOTER_RU",
+            "Рекомендуемая биржа:",
+        ).strip()
+    else:
+        prefix = os.getenv(
+            "EXTERNAL_AFF_FOOTER_EN",
+            "Recommended exchange:",
+        ).strip()
     footer = f"\n\n{prefix} {url}"
-    return (text + footer) if footer not in text else text
+    return text if footer in text else text + footer
 
 
-def publish_message(text: str) -> None:
+def publish_message(
+    text: str,
+    lang: str = "en",
+    append_aff: bool = True,
+) -> None:
+    if append_aff:
+        text = _append_aff_footer(text, lang)
     if not settings.telegram_bot_token:
-        logger.warning("TELEGRAM_BOT_TOKEN не задан — печатаю локально\n" + text)
+        logger.warning(
+            "TELEGRAM_BOT_TOKEN не задан — печатаю локально\n" + text,
+        )
         print(text)
         return
     try:
@@ -53,7 +71,6 @@ def publish_message(text: str) -> None:
         from telegram import Bot
 
         bot = Bot(token=settings.telegram_bot_token)
-        text = _append_aff_footer(text)
         dm_ids = _dm_user_ids()
         if settings.telegram_chat_id:
             for chunk in _chunk_text(text):
@@ -82,7 +99,9 @@ def publish_message(text: str) -> None:
             # Fallback: DM всем активным подписчикам из БД
             uids = list_active_subscriber_ids()
             if not uids:
-                logger.warning("Нет активных подписчиков; печатаю локально\n" + text)
+                logger.warning(
+                    "Нет активных подписчиков; печатаю локально\n" + text,
+                )
                 print(text)
             for uid in uids:
                 for chunk in _chunk_text(text):
@@ -100,7 +119,8 @@ def publish_message(text: str) -> None:
         logger.exception(f"Ошибка публикации в Telegram: {e}")
 
 
-def publish_message_to(chat_id: str, text: str) -> None:
+def publish_message_to(chat_id: str, text: str, lang: str = "en") -> None:
+    text = _append_aff_footer(text, lang)
     if not settings.telegram_bot_token or not chat_id:
         logger.warning(
             "TELEGRAM_BOT_TOKEN/CHAT_ID не заданы — печатаю локально:\n" + text
@@ -123,7 +143,9 @@ def publish_message_to(chat_id: str, text: str) -> None:
         logger.exception(f"Ошибка публикации в Telegram (target): {e}")
 
 
-def publish_photo_from_s3(s3_uri: str, caption: str | None = None) -> None:
+def publish_photo_from_s3(
+    s3_uri: str, caption: str | None = None, lang: str = "en"
+) -> None:
     if not s3_uri:
         return
     if not settings.telegram_bot_token:
@@ -141,7 +163,7 @@ def publish_photo_from_s3(s3_uri: str, caption: str | None = None) -> None:
         content = download_bytes(s3_uri)
         bot = Bot(token=settings.telegram_bot_token)
         # append footer to caption
-        caption = _append_aff_footer(caption or "")
+        caption = _append_aff_footer(caption or "", lang)
         dm_ids = _dm_user_ids()
         if settings.telegram_chat_id:
             bot.send_photo(
@@ -184,8 +206,12 @@ def publish_photo_from_s3(s3_uri: str, caption: str | None = None) -> None:
         logger.exception(f"Ошибка отправки фото в Telegram: {e}")
 
 
-def publish_code_block_json(title: str, data: dict) -> None:
+def publish_code_block_json(title: str, data: dict, lang: str = "en") -> None:
     import json
 
-    text = f"<b>{title}</b>\n<code>\n{json.dumps(data, ensure_ascii=False, indent=2)}\n</code>"
-    publish_message(text)
+    text = (
+        f"<b>{title}</b>\n<code>\n"
+        f"{json.dumps(data, ensure_ascii=False, indent=2)}\n</code>"
+    )
+    text = _append_aff_footer(text, lang)
+    publish_message(text, lang, append_aff=False)


### PR DESCRIPTION
## Summary
- support RU/EN affiliate footers in Telegram publishers
- document EXTERNAL_AFF_FOOTER_* env vars

## Testing
- `pre-commit run --files .env.example docs/ENV.md services/pipeline/src/pipeline/trading/publish_telegram.py`
- `pytest` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b120ea30833291e42e78c792be84